### PR TITLE
Improve URLProvider

### DIFF
--- a/lib/URLProvider.js
+++ b/lib/URLProvider.js
@@ -2,7 +2,7 @@ import { Component, Children, PropTypes } from 'react';
 
 const propTypes = {
   urls: PropTypes.object,
-  children: PropTypes.array,
+  children: PropTypes.element.isRequired,
 };
 const defaultProps = {
   urls: {},
@@ -24,7 +24,7 @@ class UrlProvider extends Component {
   }
 
   render() {
-    return Children.only(this.props.children[0]);
+    return Children.only(this.props.children);
   }
 }
 

--- a/test/index.js
+++ b/test/index.js
@@ -81,9 +81,7 @@ test('connected component', t => {
       {
         urls,
       },
-      [
-        createFactory(ConnectedApp)({ key: 1 }),
-      ]
+      createFactory(ConnectedApp)({ key: 1 })
     );
   }
 


### PR DESCRIPTION
Right now if i want to make this works, i have to do this.

``` jsx
const App = () => (
  <div>
    <Url.URLProvider urls={urls}>
      {[
        <div key='content'>Content</div>
      ]}
    </Url.URLProvider>
  </div>
);
```

Instead of this.

``` jsx
const App = () => (
  <div>
    <Url.URLProvider urls={urls}>
      <div key='content'>Content</div>
    </Url.URLProvider>
  </div>
);
```
